### PR TITLE
Change output library name to FFmpegJNIWrapper.dll

### DIFF
--- a/FFmpegJNIWrapper/nbproject/Makefile-Debug.mk
+++ b/FFmpegJNIWrapper/nbproject/Makefile-Debug.mk
@@ -64,11 +64,11 @@ LDLIBSOPTIONS=-Llibraries/ffmpeg-4.1.3/lib -L\"C\:/Program\ Files/Java/jdk1.8.0_
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}
-	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}
+	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}
 
-${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}: ${OBJECTFILES}
+${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}: ${OBJECTFILES}
 	${MKDIR} -p ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}
-	${LINK.c} -o ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT} ${OBJECTFILES} ${LDLIBSOPTIONS} -shared
+	${LINK.c} -o ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT} ${OBJECTFILES} ${LDLIBSOPTIONS} -shared
 
 ${OBJECTDIR}/AVCodecContextJNI.o: AVCodecContextJNI.c
 	${MKDIR} -p ${OBJECTDIR}

--- a/FFmpegJNIWrapper/nbproject/Makefile-Release_32bit.mk
+++ b/FFmpegJNIWrapper/nbproject/Makefile-Release_32bit.mk
@@ -64,11 +64,11 @@ LDLIBSOPTIONS=-Llibraries/ffmpeg-4.2.2-win32-dev/lib -lavcodec -lavdevice -lavfi
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}
-	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}
+	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}
 
-${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}: ${OBJECTFILES}
+${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}: ${OBJECTFILES}
 	${MKDIR} -p ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}
-	${LINK.c} -o ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT} ${OBJECTFILES} ${LDLIBSOPTIONS} -shared
+	${LINK.c} -o ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT} ${OBJECTFILES} ${LDLIBSOPTIONS} -shared
 
 ${OBJECTDIR}/AVCodecContextJNI.o: AVCodecContextJNI.c
 	${MKDIR} -p ${OBJECTDIR}

--- a/FFmpegJNIWrapper/nbproject/Makefile-Release_64bit.mk
+++ b/FFmpegJNIWrapper/nbproject/Makefile-Release_64bit.mk
@@ -64,11 +64,11 @@ LDLIBSOPTIONS=-Llibraries/ffmpeg-4.2.2-win64-dev/lib -lavcodec -lavdevice -lavfi
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}
-	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}
+	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}
 
-${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}: ${OBJECTFILES}
+${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}: ${OBJECTFILES}
 	${MKDIR} -p ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}
-	${LINK.c} -o ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT} ${OBJECTFILES} ${LDLIBSOPTIONS} -shared
+	${LINK.c} -o ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT} ${OBJECTFILES} ${LDLIBSOPTIONS} -shared
 
 ${OBJECTDIR}/AVCodecContextJNI.o: AVCodecContextJNI.c
 	${MKDIR} -p ${OBJECTDIR}

--- a/FFmpegJNIWrapper/nbproject/Makefile-variables.mk
+++ b/FFmpegJNIWrapper/nbproject/Makefile-variables.mk
@@ -9,27 +9,27 @@ CND_DISTDIR=dist
 # Debug configuration
 CND_PLATFORM_Debug=MinGW_64-Windows
 CND_ARTIFACT_DIR_Debug=dist/Debug/MinGW_64-Windows
-CND_ARTIFACT_NAME_Debug=libFFmpegJNIWrapper.dll
-CND_ARTIFACT_PATH_Debug=dist/Debug/MinGW_64-Windows/libFFmpegJNIWrapper.dll
+CND_ARTIFACT_NAME_Debug=FFmpegJNIWrapper.dll
+CND_ARTIFACT_PATH_Debug=dist/Debug/MinGW_64-Windows/FFmpegJNIWrapper.dll
 CND_PACKAGE_DIR_Debug=dist/Debug/MinGW_64-Windows/package
-CND_PACKAGE_NAME_Debug=libFFmpegJNIWrapper.dll.tar
-CND_PACKAGE_PATH_Debug=dist/Debug/MinGW_64-Windows/package/libFFmpegJNIWrapper.dll.tar
+CND_PACKAGE_NAME_Debug=FFmpegJNIWrapper.dll.tar
+CND_PACKAGE_PATH_Debug=dist/Debug/MinGW_64-Windows/package/FFmpegJNIWrapper.dll.tar
 # Release_32bit configuration
 CND_PLATFORM_Release_32bit=MinGW-Windows
 CND_ARTIFACT_DIR_Release_32bit=dist/Release_32bit/MinGW-Windows
-CND_ARTIFACT_NAME_Release_32bit=libFFmpegJNIWrapper.dll
-CND_ARTIFACT_PATH_Release_32bit=dist/Release_32bit/MinGW-Windows/libFFmpegJNIWrapper.dll
+CND_ARTIFACT_NAME_Release_32bit=FFmpegJNIWrapper.dll
+CND_ARTIFACT_PATH_Release_32bit=dist/Release_32bit/MinGW-Windows/FFmpegJNIWrapper.dll
 CND_PACKAGE_DIR_Release_32bit=dist/Release_32bit/MinGW-Windows/package
-CND_PACKAGE_NAME_Release_32bit=libFFmpegJNIWrapper.dll.tar
-CND_PACKAGE_PATH_Release_32bit=dist/Release_32bit/MinGW-Windows/package/libFFmpegJNIWrapper.dll.tar
+CND_PACKAGE_NAME_Release_32bit=FFmpegJNIWrapper.dll.tar
+CND_PACKAGE_PATH_Release_32bit=dist/Release_32bit/MinGW-Windows/package/FFmpegJNIWrapper.dll.tar
 # Release_64bit configuration
 CND_PLATFORM_Release_64bit=MinGW_64-Windows
 CND_ARTIFACT_DIR_Release_64bit=dist/Release_64bit/MinGW_64-Windows
-CND_ARTIFACT_NAME_Release_64bit=libFFmpegJNIWrapper.dll
-CND_ARTIFACT_PATH_Release_64bit=dist/Release_64bit/MinGW_64-Windows/libFFmpegJNIWrapper.dll
+CND_ARTIFACT_NAME_Release_64bit=FFmpegJNIWrapper.dll
+CND_ARTIFACT_PATH_Release_64bit=dist/Release_64bit/MinGW_64-Windows/FFmpegJNIWrapper.dll
 CND_PACKAGE_DIR_Release_64bit=dist/Release_64bit/MinGW_64-Windows/package
-CND_PACKAGE_NAME_Release_64bit=libFFmpegJNIWrapper.dll.tar
-CND_PACKAGE_PATH_Release_64bit=dist/Release_64bit/MinGW_64-Windows/package/libFFmpegJNIWrapper.dll.tar
+CND_PACKAGE_NAME_Release_64bit=FFmpegJNIWrapper.dll.tar
+CND_PACKAGE_PATH_Release_64bit=dist/Release_64bit/MinGW_64-Windows/package/FFmpegJNIWrapper.dll.tar
 # TESTING_64bit configuration
 CND_PLATFORM_TESTING_64bit=MinGW_64-Windows
 CND_ARTIFACT_DIR_TESTING_64bit=dist/TESTING_64bit/MinGW_64-Windows

--- a/FFmpegJNIWrapper/nbproject/Package-Debug.bash
+++ b/FFmpegJNIWrapper/nbproject/Package-Debug.bash
@@ -13,9 +13,9 @@ CND_BUILDDIR=build
 CND_DLIB_EXT=dll
 NBTMPDIR=${CND_BUILDDIR}/${CND_CONF}/${CND_PLATFORM}/tmp-packaging
 TMPDIRNAME=tmp-packaging
-OUTPUT_PATH=${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}
-OUTPUT_BASENAME=libFFmpegJNIWrapper.${CND_DLIB_EXT}
-PACKAGE_TOP_DIR=libFFmpegJNIWrapper.dll/
+OUTPUT_PATH=${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}
+OUTPUT_BASENAME=FFmpegJNIWrapper.${CND_DLIB_EXT}
+PACKAGE_TOP_DIR=FFmpegJNIWrapper.dll/
 
 # Functions
 function checkReturnCode
@@ -60,15 +60,15 @@ mkdir -p ${NBTMPDIR}
 
 # Copy files and create directories and links
 cd "${TOP}"
-makeDirectory "${NBTMPDIR}/libFFmpegJNIWrapper.dll/lib"
+makeDirectory "${NBTMPDIR}/FFmpegJNIWrapper.dll/lib"
 copyFileToTmpDir "${OUTPUT_PATH}" "${NBTMPDIR}/${PACKAGE_TOP_DIR}lib/${OUTPUT_BASENAME}" 0644
 
 
 # Generate tar file
 cd "${TOP}"
-rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/libFFmpegJNIWrapper.dll.tar
+rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/FFmpegJNIWrapper.dll.tar
 cd ${NBTMPDIR}
-tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/libFFmpegJNIWrapper.dll.tar *
+tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/FFmpegJNIWrapper.dll.tar *
 checkReturnCode
 
 # Cleanup

--- a/FFmpegJNIWrapper/nbproject/Package-Release_32bit.bash
+++ b/FFmpegJNIWrapper/nbproject/Package-Release_32bit.bash
@@ -13,9 +13,9 @@ CND_BUILDDIR=build
 CND_DLIB_EXT=dll
 NBTMPDIR=${CND_BUILDDIR}/${CND_CONF}/${CND_PLATFORM}/tmp-packaging
 TMPDIRNAME=tmp-packaging
-OUTPUT_PATH=${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}
-OUTPUT_BASENAME=libFFmpegJNIWrapper.${CND_DLIB_EXT}
-PACKAGE_TOP_DIR=libFFmpegJNIWrapper.dll/
+OUTPUT_PATH=${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}
+OUTPUT_BASENAME=FFmpegJNIWrapper.${CND_DLIB_EXT}
+PACKAGE_TOP_DIR=FFmpegJNIWrapper.dll/
 
 # Functions
 function checkReturnCode
@@ -60,15 +60,15 @@ mkdir -p ${NBTMPDIR}
 
 # Copy files and create directories and links
 cd "${TOP}"
-makeDirectory "${NBTMPDIR}/libFFmpegJNIWrapper.dll/lib"
+makeDirectory "${NBTMPDIR}/FFmpegJNIWrapper.dll/lib"
 copyFileToTmpDir "${OUTPUT_PATH}" "${NBTMPDIR}/${PACKAGE_TOP_DIR}lib/${OUTPUT_BASENAME}" 0644
 
 
 # Generate tar file
 cd "${TOP}"
-rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/libFFmpegJNIWrapper.dll.tar
+rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/FFmpegJNIWrapper.dll.tar
 cd ${NBTMPDIR}
-tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/libFFmpegJNIWrapper.dll.tar *
+tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/FFmpegJNIWrapper.dll.tar *
 checkReturnCode
 
 # Cleanup

--- a/FFmpegJNIWrapper/nbproject/Package-Release_64bit.bash
+++ b/FFmpegJNIWrapper/nbproject/Package-Release_64bit.bash
@@ -13,9 +13,9 @@ CND_BUILDDIR=build
 CND_DLIB_EXT=dll
 NBTMPDIR=${CND_BUILDDIR}/${CND_CONF}/${CND_PLATFORM}/tmp-packaging
 TMPDIRNAME=tmp-packaging
-OUTPUT_PATH=${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/libFFmpegJNIWrapper.${CND_DLIB_EXT}
-OUTPUT_BASENAME=libFFmpegJNIWrapper.${CND_DLIB_EXT}
-PACKAGE_TOP_DIR=libFFmpegJNIWrapper.dll/
+OUTPUT_PATH=${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}
+OUTPUT_BASENAME=FFmpegJNIWrapper.${CND_DLIB_EXT}
+PACKAGE_TOP_DIR=FFmpegJNIWrapper.dll/
 
 # Functions
 function checkReturnCode
@@ -60,15 +60,15 @@ mkdir -p ${NBTMPDIR}
 
 # Copy files and create directories and links
 cd "${TOP}"
-makeDirectory "${NBTMPDIR}/libFFmpegJNIWrapper.dll/lib"
+makeDirectory "${NBTMPDIR}/FFmpegJNIWrapper.dll/lib"
 copyFileToTmpDir "${OUTPUT_PATH}" "${NBTMPDIR}/${PACKAGE_TOP_DIR}lib/${OUTPUT_BASENAME}" 0644
 
 
 # Generate tar file
 cd "${TOP}"
-rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/libFFmpegJNIWrapper.dll.tar
+rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/FFmpegJNIWrapper.dll.tar
 cd ${NBTMPDIR}
-tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/libFFmpegJNIWrapper.dll.tar *
+tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/FFmpegJNIWrapper.dll.tar *
 checkReturnCode
 
 # Cleanup

--- a/JavaFFmpeg/src/jvl/FFmpeg/jni/Global.java
+++ b/JavaFFmpeg/src/jvl/FFmpeg/jni/Global.java
@@ -27,7 +27,7 @@ public class Global
             System.loadLibrary("avdevice-58");
 
             /* Load JNI library */
-            System.loadLibrary("libFFmpegJNIWrapper");           
+            System.loadLibrary("FFmpegJNIWrapper");
             
             isLirariesLoaded = true;
         }


### PR DESCRIPTION
Renaming Windows library from `libFFmpegJNIWrapper.dll` to `FFmpegJNIWrapper.dll` so that Java's `System.loadLibrary` will work the same on both Windows and Linux builds.
