### PR TITLE
Match dir name case for case sensitive filesystems

### DIFF
--- a/FFmpegJNIWrapper/Makefile
+++ b/FFmpegJNIWrapper/Makefile
@@ -64,17 +64,17 @@ build: .build-post
         ifeq (${CONF}, Release_32bit)
 		@echo 32 ------------------------------------------------- 
 	
-		if [ ! -d "../JavaFFmpeg/libraries/FFmpegJNIWrapperWin32" ];then \
+		if [ ! -d "../JavaFFmpeg/Libraries/FFmpegJNIWrapperWin32" ];then \
 			mkdir -p ../JavaFFmpeg/Libraries/FFmpegJNIWrapperWin32; \
 		fi
 	
-		cp -u -v ${CND_ARTIFACT_DIR_${CONF}}/${CND_ARTIFACT_NAME_${CONF}} ../JavaFFmpeg/libraries/FFmpegJNIWrapperWin32
-		cp -u -v libraries/ffmpeg-4.2.2-win32-dev/lib/*.dll ../JavaFFmpeg/libraries/FFmpegJNIWrapperWin32
+		cp -u -v ${CND_ARTIFACT_DIR_${CONF}}/${CND_ARTIFACT_NAME_${CONF}} ../JavaFFmpeg/Libraries/FFmpegJNIWrapperWin32
+		cp -u -v libraries/ffmpeg-4.2.2-win32-dev/lib/*.dll ../JavaFFmpeg/Libraries/FFmpegJNIWrapperWin32
 
         else ifeq (${CONF}, Release_64bit)
 		@echo 64 -------------------------------------------------
 	
-		if [ ! -d "../JavaFFmpeg/libraries/FFmpegJNIWrapperWin64" ];then \
+		if [ ! -d "../JavaFFmpeg/Libraries/FFmpegJNIWrapperWin64" ];then \
 			mkdir -p ../JavaFFmpeg/Libraries/FFmpegJNIWrapperWin64; \
 		fi
 	

--- a/JavaFFmpeg/build.xml
+++ b/JavaFFmpeg/build.xml
@@ -44,14 +44,14 @@
         </javah>
         
         <zip destfile="${dist.jar.dir}/JavaFFmpegLibraryWin64_v${build.version}.zip">
-            <fileset dir="libraries/FFmpegJNIWrapperWin64"/>
+            <fileset dir="Libraries/FFmpegJNIWrapperWin64"/>
             <zipfileset  dir="${dist.jar.dir}" includes="*.jar" prefix="JARs"/>
         </zip>
         
         <checksum file="${dist.jar.dir}/JavaFFmpegLibraryWin64_v${build.version}.zip" fileext=".md5"/>
         
         <zip destfile="${dist.jar.dir}/JavaFFmpegLibraryWin32_v${build.version}.zip">
-            <fileset dir="libraries/FFmpegJNIWrapperWin32"/>
+            <fileset dir="Libraries/FFmpegJNIWrapperWin32"/>
             <zipfileset  dir="${dist.jar.dir}" includes="*.jar" prefix="JARs"/>
         </zip>
         
@@ -85,7 +85,7 @@
         <copy file="${dist.jar}" toDir="${sagetvx64.path}\JARs"/>
 
         <copy todir="${sagetvx64.path}">  
-            <fileset dir="libraries/FFmpegJNIWrapperWin64"/>
+            <fileset dir="Libraries/FFmpegJNIWrapperWin64"/>
         </copy>
 
     </target>


### PR DESCRIPTION
Default filesytems on Linux are case sensitive.