### PR TITLE
Update config file for Windows library name

### DIFF
--- a/FFmpegJNIWrapper/nbproject/configurations.xml
+++ b/FFmpegJNIWrapper/nbproject/configurations.xml
@@ -74,6 +74,7 @@
           </incDir>
         </cTool>
         <linkerTool>
+          <output>${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}</output>
           <linkerAddLib>
             <pElem>libraries/ffmpeg-4.1.3/lib</pElem>
             <pElem>"C:/Program Files/Java/jdk1.8.0_231/lib"</pElem>
@@ -141,6 +142,7 @@
           <commandLine>-static-libgcc -Wl,--add-stdcall-alias</commandLine>
         </cTool>
         <linkerTool>
+          <output>${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}</output>
           <linkerAddLib>
             <pElem>libraries/ffmpeg-4.2.2-win32-dev/lib</pElem>
           </linkerAddLib>
@@ -205,6 +207,7 @@
           </incDir>
         </cTool>
         <linkerTool>
+          <output>${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/FFmpegJNIWrapper.${CND_DLIB_EXT}</output>
           <linkerAddLib>
             <pElem>libraries/ffmpeg-4.2.2-win64-dev/lib</pElem>
           </linkerAddLib>


### PR DESCRIPTION
I think this is the right file to change to generate the Makefile-\*.mk and Package-\*.bash files that I had updated manually (and are overwritten when building on Windows) in commit 007b6bfbc0ed9c23869fabffbaef7faeec175dc0.

I'm not sure if the Build -> Packaging Properties for the projects also need to be changed.

@jvl711 Would you be able to do a test build of this PR before merging? I don't have a Windows setup yet to verify it's behaving as expected.


